### PR TITLE
Fix XSS vulnerability in alert_msg rendering in common.jsp

### DIFF
--- a/java/timebase/webmonitor/src/main/webapp/WEB-INF/jsp/common/common.jsp
+++ b/java/timebase/webmonitor/src/main/webapp/WEB-INF/jsp/common/common.jsp
@@ -23,7 +23,7 @@
         <button type="button" class="close" data-dismiss="alert" aria-label="Close">
             <span aria-hidden="true">x</span>
         </button>
-        <strong>${alert_msg}</strong>
+        <strong><c:out value="${alert_msg}"/></strong>
     </div>
 </c:if>
 


### PR DESCRIPTION
Replaced direct output of ${alert_msg} with <c:out> to ensure HTML encoding and prevent XSS. Closes #X (replace with actual issue number if available).